### PR TITLE
Fix code scanning alert no. 23: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/docker/indexer/shared/shared.go
+++ b/docker/indexer/shared/shared.go
@@ -22,6 +22,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
+	"fmt"
 
 	"cloud.google.com/go/storage"
 )
@@ -59,11 +61,15 @@ func CopyFromBucket(ctx context.Context, bucketHdl *storage.BucketHandle, name s
 		if err != nil {
 			return "", err
 		}
-		path := filepath.Clean(filepath.Join(tmpDir, hdr.Name))
-		if err := os.MkdirAll(filepath.Dir(path), 0760); err != nil {
+		path := filepath.Join(tmpDir, hdr.Name)
+		cleanPath := filepath.Clean(path)
+		if !strings.HasPrefix(cleanPath, tmpDir) {
+			return "", fmt.Errorf("invalid file path: %s", hdr.Name)
+		}
+		if err := os.MkdirAll(filepath.Dir(cleanPath), 0760); err != nil {
 			return "", err
 		}
-		if err := os.WriteFile(path, buf, 0660); err != nil {
+		if err := os.WriteFile(cleanPath, buf, 0660); err != nil {
 			return "", err
 		}
 	}


### PR DESCRIPTION
Fixes [https://github.com/aka2024/redesigned-happiness/security/code-scanning/23](https://github.com/aka2024/redesigned-happiness/security/code-scanning/23)

To fix the problem, we need to ensure that the paths extracted from the tar archive do not contain any directory traversal elements like `..`. This can be achieved by checking the cleaned path relative to the intended extraction directory. If the relative path attempts to traverse outside the intended directory, we should skip the extraction of that file.

1. Add a check to ensure that the cleaned path does not contain any `..` elements.
2. Ensure that the final path is within the intended extraction directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
